### PR TITLE
Integrate dashboard page and fix ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.pyc
 .env
 .DS_Store
+*.db
+network.html

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-*
+# AI 문서 QA 시스템
+
+이 저장소는 FastAPI 백엔드와 Streamlit 프론트엔드로 구성된 문서 검색 및 관리 서비스 예제입니다.
+
+## 실행 방법
+1. 필요한 파이썬 패키지를 설치합니다.
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. 프로젝트 루트에 `.env` 파일을 생성하고 다음 환경 변수를 설정합니다.
+   ```env
+   OPENAI_API_KEY=your-openai-key
+   DB_URL=postgresql://user:pass@host:port/dbname  # 선택 사항, 기본은 SQLite
+   ```
+3. 백엔드와 프론트엔드를 실행합니다.
+
+## 환경 변수
+- **OPENAI_API_KEY**: LLM 호출을 위해 필수로 설정해야 합니다.
+- **DB_URL**: 데이터베이스 연결 URL. 설정하지 않으면 `p_df_main.db` SQLite 파일을 사용합니다.
+
+`.env` 파일은 민감한 정보를 포함하므로 저장소에 커밋하지 않도록 `.gitignore`에 추가되어 있습니다.

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,18 +1,35 @@
 import streamlit as st
-from pages import vectorize_ui, search_ui, document_ui, prompt_template_ui, history_log_ui
+from custom_pages import (
+    dashboard_ui,
+    vectorize_ui,
+    search_ui,
+    document_ui,
+    prompt_template_ui,
+    history_log_ui,
+)
 
 st.sidebar.title("AI 문서 QA 시스템")
-page = st.sidebar.radio("메뉴 선택", (
-    "문서 업로드", "검색/질의응답", "문서 관리", "프롬프트 관리", "히스토리 로그"
-))
+page = st.sidebar.radio(
+    "메뉴 선택",
+    (
+        "대시보드",
+        "문서 업로드",
+        "검색/질의응답",
+        "문서 관리",
+        "프롬프트 관리",
+        "히스토리 로그",
+    ),
+)
 
-if page == "문서 업로드":
-    vectorize_ui.show()
+if page == "대시보드":
+    dashboard_ui.render()
+elif page == "문서 업로드":
+    vectorize_ui.render()
 elif page == "검색/질의응답":
-    search_ui.show()
+    search_ui.render()
 elif page == "문서 관리":
-    document_ui.show()
+    document_ui.render()
 elif page == "프롬프트 관리":
-    prompt_template_ui.show()
+    prompt_template_ui.render()
 elif page == "히스토리 로그":
-    history_log_ui.show()
+    history_log_ui.render()


### PR DESCRIPTION
## Summary
- include dashboard as an option in the Streamlit sidebar
- call each page's `render()` method
- document required environment variables in README
- rename `.gitgnore` to `.gitignore` and ignore DB files

## Testing
- `python -m py_compile frontend/app.py frontend/custom_pages/*.py backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687e74ecd56c83308bfd241bb719457b