### PR TITLE
Fix uvicorn command in docs

### DIFF
--- a/architecture_doc.md
+++ b/architecture_doc.md
@@ -75,7 +75,7 @@
 
 ```bash
 # 백엔드 실행
-uvicorn backend.api_router:app --reload
+uvicorn backend.main:app --reload
 
 # 프론트 실행
 streamlit run app_dashboard_enhanced.py


### PR DESCRIPTION
## Summary
- correct FastAPI run command in `architecture_doc.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68801bcb75288330bc2a4c51c7420f94